### PR TITLE
feat: add massive patient import via background jobs

### DIFF
--- a/app/Http/Controllers/Admin/PatientController.php
+++ b/app/Http/Controllers/Admin/PatientController.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Jobs\ImportPatientsJob;
+use App\Models\ImportLog;
 use App\Models\Patient;
 use Illuminate\Support\Facades\Auth;
 use App\Models\BloodType;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class PatientController extends Controller
 {
@@ -91,5 +94,96 @@ class PatientController extends Controller
     public function destroy(Patient $patient)
     {
         //
+    }
+
+    /**
+     * Muestra el formulario para importación masiva de pacientes.
+     */
+    public function importForm()
+    {
+        $imports = ImportLog::where('user_id', Auth::id())
+            ->latest()
+            ->take(10)
+            ->get();
+
+        return view('admin.patients.import', compact('imports'));
+    }
+
+    /**
+     * Recibe el archivo CSV/Excel y despacha el job en segundo plano.
+     */
+    public function import(Request $request)
+    {
+        $request->validate([
+            'file' => 'required|file|mimes:csv,txt|max:51200', // max 50 MB
+        ], [
+            'file.required' => 'Debes seleccionar un archivo.',
+            'file.mimes'    => 'Solo se aceptan archivos CSV (.csv).',
+            'file.max'      => 'El archivo no debe superar los 50 MB.',
+        ]);
+
+        $uploadedFile = $request->file('file');
+        $fileName     = $uploadedFile->getClientOriginalName();
+
+        // Guardar en storage/app/imports de forma temporal
+        $path = $uploadedFile->store('imports');
+
+        // Contar filas (excluyendo encabezado)
+        $totalRows = max(0, count(file(Storage::path($path))) - 1);
+
+        // Crear registro de log
+        $importLog = ImportLog::create([
+            'user_id'   => Auth::id(),
+            'file_name' => $fileName,
+            'status'    => 'pending',
+            'total_rows'=> $totalRows,
+        ]);
+
+        // Despachar el job a la cola (segundo plano)
+        ImportPatientsJob::dispatch($path, $importLog->id);
+
+        session()->flash('swal', [
+            'icon'  => 'success',
+            'title' => '¡Importación iniciada!',
+            'text'  => "El archivo '{$fileName}' está siendo procesado en segundo plano. Puedes consultar el estado más abajo.",
+        ]);
+
+        return redirect()->route('admin.admin.patients.import-form');
+    }
+
+    /**
+     * Descarga la plantilla CSV de ejemplo.
+     */
+    public function downloadTemplate()
+    {
+        $headers = [
+            'Content-Type'        => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="plantilla_pacientes.csv"',
+        ];
+
+        $columns = [
+            'nombre', 'email', 'cedula', 'telefono', 'direccion',
+            'tipo_sangre', 'alergias', 'enfermedades_cronicas',
+            'historial_quirurgico', 'historial_familiar',
+            'contacto_emergencia', 'telefono_emergencia', 'relacion_emergencia',
+        ];
+
+        $example = [
+            'Juan Pérez', 'juan.perez@ejemplo.com', '1234567890',
+            '8888-8888', 'Calle Principal 123',
+            'O+', 'Polen', 'Diabetes tipo 2',
+            'Apendicectomía 2010', 'Hipertensión paterna',
+            'María Pérez', '7777-7777', 'Esposa',
+        ];
+
+        $callback = function () use ($columns, $example) {
+            $handle = fopen('php://output', 'w');
+            fprintf($handle, chr(0xEF) . chr(0xBB) . chr(0xBF)); // BOM UTF-8
+            fputcsv($handle, $columns);
+            fputcsv($handle, $example);
+            fclose($handle);
+        };
+
+        return response()->stream($callback, 200, $headers);
     }
 }

--- a/app/Jobs/ImportPatientsJob.php
+++ b/app/Jobs/ImportPatientsJob.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\BloodType;
+use App\Models\ImportLog;
+use App\Models\Patient;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ImportPatientsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+    public int $timeout = 600; // 10 minutos
+
+    public function __construct(
+        public readonly string $filePath,
+        public readonly int $importLogId
+    ) {}
+
+    public function handle(): void
+    {
+        $importLog = ImportLog::findOrFail($this->importLogId);
+        $importLog->update(['status' => 'processing']);
+
+        $errors = [];
+        $processed = 0;
+        $failed = 0;
+
+        try {
+            $fullPath = Storage::path($this->filePath);
+
+            if (! file_exists($fullPath)) {
+                $importLog->update(['status' => 'failed', 'errors' => ['El archivo no fue encontrado.']]);
+                return;
+            }
+
+            $handle = fopen($fullPath, 'r');
+            $header = fgetcsv($handle); // primera fila = encabezados
+
+            if ($header === false) {
+                $importLog->update(['status' => 'failed', 'errors' => ['El archivo está vacío o no es un CSV válido.']]);
+                fclose($handle);
+                return;
+            }
+
+            // Normalizar encabezados (trim + minúsculas)
+            $header = array_map(fn($h) => trim(strtolower($h)), $header);
+
+            $rowNumber = 1;
+            while (($row = fgetcsv($handle)) !== false) {
+                $rowNumber++;
+
+                if (count($row) !== count($header)) {
+                    $errors[] = "Fila {$rowNumber}: número de columnas incorrecto.";
+                    $failed++;
+                    continue;
+                }
+
+                $data = array_combine($header, $row);
+
+                try {
+                    $this->processRow($data, $rowNumber);
+                    $processed++;
+                } catch (\Throwable $e) {
+                    $errors[] = "Fila {$rowNumber}: " . $e->getMessage();
+                    $failed++;
+                    Log::warning("ImportPatientsJob - Fila {$rowNumber} fallida: " . $e->getMessage());
+                }
+
+                // Actualizar progreso cada 50 filas
+                if ($rowNumber % 50 === 0) {
+                    $importLog->update([
+                        'processed_rows' => $processed,
+                        'failed_rows'    => $failed,
+                    ]);
+                }
+            }
+
+            fclose($handle);
+            Storage::delete($this->filePath);
+
+            $importLog->update([
+                'status'         => 'completed',
+                'processed_rows' => $processed,
+                'failed_rows'    => $failed,
+                'errors'         => $errors ?: null,
+            ]);
+
+        } catch (\Throwable $e) {
+            Log::error('ImportPatientsJob falló: ' . $e->getMessage());
+            $importLog->update([
+                'status'         => 'failed',
+                'processed_rows' => $processed,
+                'failed_rows'    => $failed,
+                'errors'         => array_merge($errors, ['Error crítico: ' . $e->getMessage()]),
+            ]);
+        }
+    }
+
+    private function processRow(array $data, int $rowNumber): void
+    {
+        $name    = trim($data['nombre'] ?? $data['name'] ?? '');
+        $email   = trim($data['email'] ?? $data['correo'] ?? '');
+        $idNum   = trim($data['cedula'] ?? $data['id_number'] ?? $data['numero_identidad'] ?? '');
+        $phone   = trim($data['telefono'] ?? $data['phone'] ?? '');
+        $address = trim($data['direccion'] ?? $data['address'] ?? '');
+
+        if (empty($name) || empty($email) || empty($idNum)) {
+            throw new \InvalidArgumentException('Los campos nombre, email y cédula son obligatorios.');
+        }
+
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new \InvalidArgumentException("El email '{$email}' no es válido.");
+        }
+
+        if (User::where('email', $email)->exists() || User::where('id_number', $idNum)->exists()) {
+            throw new \InvalidArgumentException("El usuario con email '{$email}' o cédula '{$idNum}' ya existe.");
+        }
+
+        // Resolver tipo de sangre por nombre (opcional)
+        $bloodTypeId = null;
+        $bloodTypeName = trim($data['tipo_sangre'] ?? $data['blood_type'] ?? '');
+        if ($bloodTypeName !== '') {
+            $bloodType = BloodType::where('name', $bloodTypeName)->first();
+            if ($bloodType) {
+                $bloodTypeId = $bloodType->id;
+            }
+        }
+
+        DB::transaction(function () use ($data, $name, $email, $idNum, $phone, $address, $bloodTypeId) {
+            $user = User::create([
+                'name'      => $name,
+                'email'     => $email,
+                'id_number' => $idNum,
+                'phone'     => $phone ?: 'N/A',
+                'address'   => $address ?: 'N/A',
+                'password'  => Hash::make(Str::random(16)),
+            ]);
+
+            Patient::create([
+                'user_id'                       => $user->id,
+                'blood_type_id'                 => $bloodTypeId,
+                'allergies'                     => $data['alergias'] ?? $data['allergies'] ?? null,
+                'chronic_conditions'            => $data['enfermedades_cronicas'] ?? $data['chronic_conditions'] ?? null,
+                'surgical_history'              => $data['historial_quirurgico'] ?? $data['surgical_history'] ?? null,
+                'family_history'                => $data['historial_familiar'] ?? $data['family_history'] ?? null,
+                'emergency_contact_name'        => $data['contacto_emergencia'] ?? $data['emergency_contact_name'] ?? null,
+                'emergency_contact_phone'       => $data['telefono_emergencia'] ?? $data['emergency_contact_phone'] ?? null,
+                'emergency_contact_relationship'=> $data['relacion_emergencia'] ?? $data['emergency_contact_relationship'] ?? null,
+            ]);
+        });
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('ImportPatientsJob falló definitivamente: ' . $exception->getMessage());
+
+        ImportLog::where('id', $this->importLogId)->update([
+            'status' => 'failed',
+            'errors' => ['El job fue rechazado por la cola: ' . $exception->getMessage()],
+        ]);
+    }
+}

--- a/app/Models/ImportLog.php
+++ b/app/Models/ImportLog.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ImportLog extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'file_name',
+        'status',
+        'total_rows',
+        'processed_rows',
+        'failed_rows',
+        'errors',
+    ];
+
+    protected $casts = [
+        'errors' => 'array',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function getStatusLabelAttribute(): string
+    {
+        return match ($this->status) {
+            'pending'    => 'Pendiente',
+            'processing' => 'Procesando',
+            'completed'  => 'Completado',
+            'failed'     => 'Fallido',
+            default      => $this->status,
+        };
+    }
+}

--- a/database/migrations/2026_03_26_163212_create_import_logs_table.php
+++ b/database/migrations/2026_03_26_163212_create_import_logs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('import_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('file_name');
+            $table->string('status')->default('pending'); // pending, processing, completed, failed
+            $table->integer('total_rows')->default(0);
+            $table->integer('processed_rows')->default(0);
+            $table->integer('failed_rows')->default(0);
+            $table->text('errors')->nullable(); // JSON array of error messages
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('import_logs');
+    }
+};

--- a/resources/views/admin/patients/import.blade.php
+++ b/resources/views/admin/patients/import.blade.php
@@ -1,0 +1,229 @@
+<x-admin-layout
+    title="Importar Pacientes | Dendro Medical"
+    :breadcrumbs="[
+        ['name' => 'Dashboard', 'href' => route('admin.dashboard')],
+        ['name' => 'Pacientes',  'href' => route('admin.admin.patients.index')],
+        ['name' => 'Importación Masiva'],
+    ]">
+
+    {{-- Encabezado de acción --}}
+    <x-wire-card class="mt-10">
+        <div class="lg:flex lg:justify-between lg:items-center">
+            <div>
+                <h1 class="text-2xl font-bold text-gray-900">
+                    <i class="fa-solid fa-file-arrow-up text-blue-500 mr-2"></i>
+                    Importación Masiva de Pacientes
+                </h1>
+                <p class="text-gray-500 text-sm mt-1">
+                    Sube un archivo CSV con la información de múltiples pacientes. El procesamiento
+                    se realizará en <strong>segundo plano</strong> para no bloquear el sistema.
+                </p>
+            </div>
+            <div class="mt-4 lg:mt-0 flex space-x-3">
+                <x-wire-button outline gray href="{{ route('admin.admin.patients.index') }}">
+                    <i class="fa-solid fa-arrow-left mr-2"></i>
+                    Volver
+                </x-wire-button>
+                <x-wire-button outline teal href="{{ route('admin.admin.patients.import-template') }}">
+                    <i class="fa-solid fa-download mr-2"></i>
+                    Descargar plantilla CSV
+                </x-wire-button>
+            </div>
+        </div>
+    </x-wire-card>
+
+    {{-- Instrucciones --}}
+    <x-wire-card class="mt-4">
+        <h2 class="text-base font-semibold text-gray-800 mb-3">
+            <i class="fa-solid fa-circle-info text-blue-400 mr-1"></i>
+            Formato requerido del archivo CSV
+        </h2>
+
+        <div class="overflow-x-auto rounded-lg border border-gray-200">
+            <table class="min-w-full text-xs text-left text-gray-600">
+                <thead class="bg-gray-50 text-gray-700 uppercase">
+                    <tr>
+                        <th class="px-4 py-2">Columna</th>
+                        <th class="px-4 py-2">Descripción</th>
+                        <th class="px-4 py-2">Obligatorio</th>
+                        <th class="px-4 py-2">Ejemplo</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach ([
+                        ['nombre',                 'Nombre completo del paciente',            true,  'Juan Pérez'],
+                        ['email',                  'Correo electrónico (único)',               true,  'juan@ejemplo.com'],
+                        ['cedula',                 'Número de identidad (único)',              true,  '1234567890'],
+                        ['telefono',               'Teléfono de contacto',                    false, '8888-8888'],
+                        ['direccion',              'Dirección de residencia',                 false, 'Calle 1, San José'],
+                        ['tipo_sangre',            'Tipo de sangre (debe existir en el sistema)', false, 'O+'],
+                        ['alergias',               'Alergias conocidas',                      false, 'Polen, polvo'],
+                        ['enfermedades_cronicas',  'Enfermedades crónicas',                   false, 'Diabetes tipo 2'],
+                        ['historial_quirurgico',   'Historial de cirugías',                   false, 'Apendicectomía 2010'],
+                        ['historial_familiar',     'Antecedentes familiares',                 false, 'Hipertensión paterna'],
+                        ['contacto_emergencia',    'Nombre del contacto de emergencia',       false, 'María Pérez'],
+                        ['telefono_emergencia',    'Teléfono del contacto de emergencia',     false, '7777-7777'],
+                        ['relacion_emergencia',    'Relación con el paciente',                false, 'Esposa'],
+                    ] as [$col, $desc, $req, $ej])
+                    <tr>
+                        <td class="px-4 py-2 font-mono font-semibold text-blue-700">{{ $col }}</td>
+                        <td class="px-4 py-2">{{ $desc }}</td>
+                        <td class="px-4 py-2">
+                            @if($req)
+                                <span class="inline-block bg-red-100 text-red-700 text-xs font-semibold px-2 py-0.5 rounded-full">Sí</span>
+                            @else
+                                <span class="inline-block bg-gray-100 text-gray-500 text-xs px-2 py-0.5 rounded-full">No</span>
+                            @endif
+                        </td>
+                        <td class="px-4 py-2 text-gray-500 italic">{{ $ej }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <p class="text-xs text-gray-400 mt-3">
+            <i class="fa-solid fa-triangle-exclamation text-amber-400 mr-1"></i>
+            La primera fila debe ser el encabezado. El sistema generará una contraseña temporal aleatoria para cada paciente.
+        </p>
+    </x-wire-card>
+
+    {{-- Formulario de carga --}}
+    <x-wire-card class="mt-4">
+        <h2 class="text-base font-semibold text-gray-800 mb-4">
+            <i class="fa-solid fa-upload text-blue-400 mr-1"></i>
+            Subir archivo CSV
+        </h2>
+
+        <form action="{{ route('admin.admin.patients.import') }}" method="POST" enctype="multipart/form-data">
+            @csrf
+
+            <div x-data="{ fileName: '', dragging: false }"
+                 class="relative border-2 border-dashed rounded-xl p-8 text-center transition-colors duration-200"
+                 :class="dragging ? 'border-blue-500 bg-blue-50' : 'border-gray-300 hover:border-blue-400 bg-gray-50'"
+                 @dragover.prevent="dragging = true"
+                 @dragleave.prevent="dragging = false"
+                 @drop.prevent="dragging = false; fileName = $event.dataTransfer.files[0]?.name; $refs.fileInput.files = $event.dataTransfer.files">
+
+                <input type="file"
+                       name="file"
+                       accept=".csv,.txt"
+                       x-ref="fileInput"
+                       class="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                       @change="fileName = $event.target.files[0]?.name">
+
+                <i class="fa-solid fa-file-csv text-5xl mb-3"
+                   :class="fileName ? 'text-green-400' : 'text-gray-300'"></i>
+
+                <p class="text-gray-600 font-medium" x-text="fileName || 'Arrastra tu archivo CSV aquí'"></p>
+                <p class="text-gray-400 text-sm mt-1" x-show="!fileName">o haz clic para seleccionarlo</p>
+                <p class="text-green-600 text-sm mt-1 font-semibold" x-show="fileName">
+                    <i class="fa-solid fa-circle-check mr-1"></i>
+                    Archivo seleccionado
+                </p>
+            </div>
+
+            @error('file')
+                <p class="text-red-600 text-sm mt-2 flex items-center">
+                    <i class="fa-solid fa-circle-exclamation mr-1"></i>
+                    {{ $message }}
+                </p>
+            @enderror
+
+            <div class="mt-6 flex justify-end">
+                <x-wire-button type="submit">
+                    <i class="fa-solid fa-paper-plane mr-2"></i>
+                    Iniciar importación en segundo plano
+                </x-wire-button>
+            </div>
+        </form>
+    </x-wire-card>
+
+    {{-- Historial de importaciones --}}
+    @if($imports->isNotEmpty())
+    <x-wire-card class="mt-4 mb-10">
+        <div class="flex items-center justify-between mb-4">
+            <h2 class="text-base font-semibold text-gray-800">
+                <i class="fa-solid fa-clock-rotate-left text-blue-400 mr-1"></i>
+                Historial de importaciones recientes
+            </h2>
+            <button onclick="window.location.reload()"
+                    class="text-xs text-blue-500 hover:text-blue-700 flex items-center gap-1">
+                <i class="fa-solid fa-arrows-rotate"></i>
+                Actualizar estado
+            </button>
+        </div>
+
+        <div class="overflow-x-auto rounded-lg border border-gray-200">
+            <table class="min-w-full text-sm text-left text-gray-600">
+                <thead class="bg-gray-50 text-gray-700 uppercase text-xs">
+                    <tr>
+                        <th class="px-4 py-3">Archivo</th>
+                        <th class="px-4 py-3">Estado</th>
+                        <th class="px-4 py-3 text-center">Total filas</th>
+                        <th class="px-4 py-3 text-center">Procesadas</th>
+                        <th class="px-4 py-3 text-center">Fallidas</th>
+                        <th class="px-4 py-3">Iniciado</th>
+                        <th class="px-4 py-3">Errores</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach($imports as $import)
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-4 py-3 font-medium text-gray-800 max-w-xs truncate">
+                            <i class="fa-solid fa-file-csv text-blue-400 mr-1"></i>
+                            {{ $import->file_name }}
+                        </td>
+                        <td class="px-4 py-3">
+                            @php
+                                $badge = match($import->status) {
+                                    'pending'    => 'bg-yellow-100 text-yellow-700',
+                                    'processing' => 'bg-blue-100 text-blue-700',
+                                    'completed'  => 'bg-green-100 text-green-700',
+                                    'failed'     => 'bg-red-100 text-red-700',
+                                    default      => 'bg-gray-100 text-gray-600',
+                                };
+                                $icon = match($import->status) {
+                                    'pending'    => 'fa-hourglass-start',
+                                    'processing' => 'fa-spinner fa-spin',
+                                    'completed'  => 'fa-circle-check',
+                                    'failed'     => 'fa-circle-xmark',
+                                    default      => 'fa-question',
+                                };
+                            @endphp
+                            <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-semibold {{ $badge }}">
+                                <i class="fa-solid {{ $icon }}"></i>
+                                {{ $import->status_label }}
+                            </span>
+                        </td>
+                        <td class="px-4 py-3 text-center">{{ $import->total_rows }}</td>
+                        <td class="px-4 py-3 text-center text-green-600 font-semibold">{{ $import->processed_rows }}</td>
+                        <td class="px-4 py-3 text-center {{ $import->failed_rows > 0 ? 'text-red-600 font-semibold' : '' }}">
+                            {{ $import->failed_rows }}
+                        </td>
+                        <td class="px-4 py-3 text-gray-400 text-xs">{{ $import->created_at->diffForHumans() }}</td>
+                        <td class="px-4 py-3">
+                            @if($import->errors && count($import->errors))
+                                <details class="text-xs">
+                                    <summary class="text-red-500 cursor-pointer hover:text-red-700 font-medium">
+                                        Ver {{ count($import->errors) }} error(es)
+                                    </summary>
+                                    <ul class="mt-2 space-y-1 text-gray-500 max-h-32 overflow-y-auto list-disc list-inside">
+                                        @foreach($import->errors as $err)
+                                            <li>{{ $err }}</li>
+                                        @endforeach
+                                    </ul>
+                                </details>
+                            @else
+                                <span class="text-gray-300">—</span>
+                            @endif
+                        </td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </x-wire-card>
+    @endif
+
+</x-admin-layout>

--- a/resources/views/admin/patients/index.blade.php
+++ b/resources/views/admin/patients/index.blade.php
@@ -12,5 +12,12 @@
         ],
     ]">
 
+    <div class="flex justify-end mb-4 mt-4">
+        <x-wire-button href="{{ route('admin.admin.patients.import-form') }}" teal>
+            <i class="fa-solid fa-file-arrow-up mr-2"></i>
+            Importación Masiva
+        </x-wire-button>
+    </div>
+
     @livewire('admin.data-tables.patient-table')
 </x-admin-layout>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -23,6 +23,9 @@ Route::resource('users', UserController::class)->names('admin.users');
 
 // Gestión de pacientes
 Route::resource('patients', PatientController::class)->names('admin.patients');
+Route::get('patients-import', [PatientController::class, 'importForm'])->name('admin.patients.import-form');
+Route::post('patients-import', [PatientController::class, 'import'])->name('admin.patients.import');
+Route::get('patients-import/template', [PatientController::class, 'downloadTemplate'])->name('admin.patients.import-template');
 
 // Gestión de doctores
 Route::resource('doctors', DoctorController::class)->names('admin.doctors');


### PR DESCRIPTION
Implements CSV bulk-import of patients using Laravel Queues so the UI is never blocked while processing large files.

- ImportPatientsJob: reads CSV rows, creates User + Patient per row inside a DB transaction, updates progress, handles per-row errors
- ImportLog model + migration: tracks file name, status, row counts and per-row error messages (pending → processing → completed/failed)
- PatientController: importForm(), import(), downloadTemplate() methods
- Routes: GET/POST patients-import, GET patients-import/template
- View: drag-and-drop upload form, column reference table, import history
- Patients index: "Importación Masiva" button linking to the new form